### PR TITLE
Problem: Reward distribution paramters range are not reasonable enough

### DIFF
--- a/docs/getting-started/staking.md
+++ b/docs/getting-started/staking.md
@@ -116,9 +116,9 @@ Configuration section in `genesis.json` for this:
     "network_params": {
       ...
       "rewards_config": {
-        "reward_period_seconds": 86400,  # range: [0, )
+        "reward_period_seconds": 86400,  # range: [0, 365 * 86400]
         "monetary_expansion_r0": 450,  # range: [0, 1000]
-        "monetary_expansion_tau": 14500000000000000,  # range: [1, 100_00000000_00000000]
+        "monetary_expansion_tau": 14500000000000000,  # range: [1, 2**64 - 1]
         "monetary_expansion_decay": 999860,  # range: [0, 1000000]
         "monetary_expansion_cap": "6250000000000000000" # range: [0, 100_00000000_00000000]
       }


### PR DESCRIPTION
Solution:
Change it with better reasonings:

- `monetary_expansion_cap`, this one is obvious, because it's amount of coins, so it should not be negative and should be `<= max supply`.
- `monetary_expansion_decay`, it should be unsigned and `<= 1000000` to make sure `decay / 1000000 <= 1`, so it's actually "decay" a value when multiplied. And the internal unsigned integer calculation needs this constraint to not overflow.
- `monetary_expansion_tau`, `u64`, `!= 0`, no extra constraints.  tau is only involved in computation of `exp(-S / tau)`, and unit tests verifies that both `exp(-1 / std::u64::MAX)` and `exp(-Coin::max() / 1)` are OK.
- `reward_period_seconds`, `period / seconds of a year <= 1`,
- `monetary_expansion_r0`, `r0 / 1000 <= 1`, first of all, it's reasonable to keep reward rate smaller than 1, and `r0` is the upper bound of p.a.