### PR TITLE
Problem: Punishments are not defined precisely

### DIFF
--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -100,3 +100,8 @@ A validator should not be slashed more than once within `UNBONDING_PERIOD`. If a
 within that time period, it should only be slashed once (for simplicity, we'll only slash the validator for the first
 evidence that we get from tendermint and ignore other evidences until `UNBONDING_PERIOD`).
 :::
+
+:::tip Implementation note:
+To enforce that we only slash an account only once within `UNBONDING_PERIOD`, we can just check if an account is
+not jailed when we receive evidence of misbehavior from tendermint.
+:::

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -1,0 +1,153 @@
+# Validator Punishments
+
+This part describes functionality that aims to dis-incentivize network-observable actions, such as faulty validations,
+of participants with values at stake by penalizing/slashing and jailing them. The penalties may include losing some
+amount of their stake (surrendered to the rewards pool), losing their ability to perform the network functionality for a
+period of time, collect rewards etc.
+
+## Network Parameters
+
+Below are all the network parameters used to configure the behavior of validator punishments. Details of all these
+parameters and their effect on behavior of validator punishments is discussed later in this document.
+
+1. `UNBONDING_PERIOD`: Unbonding period will be used as jailing period (time for which an account is jailed after it
+   gets punished) and also as slashing period (time to wait before slashing funds from an account). This should be
+   greater than or equal to `MAX_EVIDENCE_AGE` in tendermint.
+1. `BLOCK_SIGNING_WINDOW`: Number of blocks for which the moving average is calculated for uptime tracking.
+1. `MISSED_BLOCK_THRESHOLD`: Maximum number of blocks with faulty/missed validations allowed for an account in last
+   `BLOCK_SIGNING_WINDOW` blocks before it gets jailed.
+1. `LIVENESS_SLASH_PERCENT`: Percentage of funds (bonded + unbonded) slashed when validator is not live.
+1. `BYZANTINE_SLASH_PERCENT`: Percentage of funds (bonded + unbonded) slashed when validator makes a byzantine fault.
+
+:::tip Important:
+During slashing, funds are slashed from both, bonded and unbonded, amounts.
+:::
+
+## Overview
+
+Punishments for a validator are triggered when they either make a *byzantine fault* or become *non-live*: 
+
+- Liveness Faults (Low availability)
+
+    A validator is said to be **non-live** when they fail to sign at least `MISSED_BLOCK_THRESHOLD` blocks in
+    last `BLOCK_SIGNING_WINDOW` blocks successfully. `BLOCK_SIGNING_WINDOW` and `MISSED_BLOCK_THRESHOLD` are network
+    parameters and can be configured during genesis (currently, changing these network parameters at runtime is not
+    supported). Tendermint passes signing information to ABCI application as `last_commit_info` in `BeginBlock` request.
+
+:::tip Example:
+For example, if `BLOCK_SIGNING_WINDOW` is `100` blocks and `MISSED_BLOCK_THRESHOLD` is `50` blocks, a validator will
+be marked as **non-live** if they fail to successfully sign at least `50` blocks in last `100` blocks.
+:::
+
+- Byzantine Faults (Double signing)
+
+    A validator is said to make a byzantine fault when they sign conflicting transactions at the same height and round.
+    Tendermint has mechanisms to publish evidence of validators that signed conflicting votes (it passes this 
+    information to ABCI application in `BeginBlock` request), so they can be punished by the application.
+
+:::tip Implementation note:
+Tendermint passes `Evidence` of a byzantine validator in `BeginBlock` request. Before jailing any account because of
+byzantine fault, that evidence should be verified. Also, it should be checked that evidence provided by tendermint is
+not older than `MAX_EVIDENCE_AGE` in tendermint.
+:::
+
+### Jailing
+
+A validator is jailed if:
+
+1. They are not **live**, i.e., they failed to sign `MISSED_BLOCK_THRESHOLD` blocks in last
+   `BLOCK_SIGNING_WINDOW` blocks successfully. 
+1. They make a byzantine fault, e.g., they sign messages at same height and round.
+
+When a validator gets jailed, they cannot perform any operations relating to their account, for example,
+`withdraw_stake`, `deposit_stake`, `unbond_stake`, etc., until they are un-jailed. Also, a validator cannot be un-jailed
+before `account.jailed_until` which is set to `block_time + UNBONDING_PERIOD` while jailing. `UNBONDING_PERIOD` is a
+network parameter which can be configured during genesis.
+
+:::tip Important:
+`block_time` used in calculating `account.jailed_until` should be the time of the block at which the validator made the
+fault, which can be obtained from `evidence` provided by tendermint (current block for liveness faults).
+:::
+
+#### Un-jailing and Re-joining 
+
+When a jailed validator wishes to resume normal operations (after `account.jailed_until` has passed and the account is
+slashed), they can create `UnjailTx` which marks them as un-jailed. After successful un-jailing, validators can submit a
+`NodeJoinTx`, which will add them back to validator set.
+
+:::tip Important:
+`UnjailTx` should only be valid after funds are slashed from jailed account.
+:::
+
+### Slashing
+
+Validators are responsible for signing or proposing block at each consensus round. It is important that they maintain
+excellent availability and network connectivity to perform these tasks. A penalty performed by the slashing module
+should be imposed on validators' misbehavior or unavailability to reinforce this. Similar to jailing, a validator is
+slashed if:
+
+1. They are not **live**, i.e., they failed to sign `MISSED_BLOCK_THRESHOLD` blocks in last `BLOCK_SIGNING_WINDOW`
+   blocks successfully.
+1. They make a byzantine fault, e.g., they sign messages at same height and round.
+
+Unlike jailing, which happens immediately after punishments are triggered, slashing happens after `UNBONDING_PERIOD`.
+`UNBONDING_PERIOD` is a network parameter and can be configured during genesis. Validators are not immediately slashed
+because evidence for more faulty may be discovered after some time. If a validator makes multiple faults in
+`UNBONDING_PERIOD`, they'll only be slashed once for the worst fault in that period.
+
+:::tip Implementation note:
+It should be enforced in implementation that un-jailing can only be done after an account is slashed. So, even if an
+account can be un-jailed after `UNBONDING_PERIOD`, it should not be allowed to un-jail until it has been slashed.
+:::
+
+:::tip Important:
+A validator should not be slashed more than once within `UNBONDING_PERIOD`. If we get multiple slash requests for a
+validator within `UNBONDING_PERIOD`, we should ignore all requests other than the first one.
+:::
+
+#### Slashing Rate
+
+Whenever a validator is slashed, a percentage of their `bonded` and `unbonded` amount is transferred to `rewards_pool`.
+There are many factors involved in determining the slashing rate for a validator:
+
+1. `LIVENESS_SLASH_PERCENT` and `BYZANTINE_SLASH_PERCENT` are the two network parameters used while calculating the
+   slashing rate. Both of these can be configured in the genesis.
+1. `validator_voting_percent` is the voting percent of faulty validator in block `H` (`H` is the height of the block
+   when the validator made the fault).
+1. List of all the faulty validators in the block `H` and their `validator_voting_percent`s (according to above
+   definition).
+
+The algorithm for calculating `slashing_rate` is as follows:
+
+```
+validator_slash_percent = max(slash percent of individual faults)
+```
+
+For example, if a validator made a byzantine fault as well as they are non-live, then,
+
+```
+validator_slash_percent = max(liveness_slash_percent, byzantine_slash_percent)
+```
+
+And if there are `n` faulty validators in this period, then,
+
+```
+slashing_rate = 
+    validator_slash_percent * 
+    (
+        sqrt(validator_voting_percent_1) +
+        sqrt(validator_voting_percent_2) +
+        .. + 
+        sqrt(validator_voting_percent_n)
+    )^2
+```
+
+So, if one validator of 10% voting power faults, it gets a 10% slash (assuming `liveness_slash_percent` and
+`byzantine_slash_percent` are both 100%). While, if two validators of 5% voting power each fault together, they both get
+a 20% slash.
+
+```
+slashing_rate = max(liveness_slash_percent, byzantine_slash_percent) * (sqrt(validator_voting_percent_1) + sqrt(validator_voting_percent_2))^2
+              = max(1, 1) * (sqrt(0.05) + sqrt(0.05))^2                // assuming liveness_slash_percent and byzantine_slash_percent are both 100%
+              = 0.2
+```

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -101,9 +101,9 @@ account can be un-jailed after `UNBONDING_PERIOD`, it should not be allowed to u
 :::
 
 :::tip Important:
-A validator should not be slashed more than once within `UNBONDING_PERIOD`. I a validator commits multiple faults before
-`account.jailed_until`, it should only be slashed with the highest slash amount in that period (can be calculated using
-below algorithm).
+A validator should not be slashed more than once within `UNBONDING_PERIOD`. If a validator commits multiple faults
+before `account.jailed_until`, it should only be slashed with the highest slash amount in that period (can be calculated
+using below algorithm).
 :::
 
 #### Slashing Rate

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -41,8 +41,8 @@ be marked as **non-live** if they fail to successfully sign at least `50` blocks
 
 - Byzantine Faults (Double signing)
 
-    A validator is said to make a byzantine fault when they sign conflicting transactions at the same height and round.
-    Tendermint has mechanisms to publish evidence of validators that signed conflicting votes (it passes this 
+    A validator is said to make a byzantine fault when they sign conflicting messages/blocks at the same height and
+    round. Tendermint has mechanisms to publish evidence of validators that signed conflicting votes (it passes this 
     information to ABCI application in `BeginBlock` request), so they can be punished by the application.
 
 :::tip Implementation note:

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -101,7 +101,7 @@ account can be un-jailed after `UNBONDING_PERIOD`, it should not be allowed to u
 :::
 
 :::tip Important:
-A validator should not be slashed more than once within `UNBONDING_PERIOD`. If a validator commits multiple faults
+A validator should not be slashed more than once within `UNBONDING_PERIOD` after they were jailed. If a validator commits multiple faults
 before `account.jailed_until`, it should only be slashed with the highest slash amount in that period (can be calculated
 using below algorithm).
 :::

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -84,7 +84,7 @@ slashed), they can create `UnjailTx` which marks them as un-jailed. After succes
 Validators are responsible for signing or proposing block at each consensus round. It is important that they maintain
 excellent availability and network connectivity to perform these tasks. A penalty performed by the slashing module
 should be imposed on validators' misbehavior or unavailability to reinforce this. Similar to jailing, a validator is
-slashed if:
+slashed if any one of the following applies:
 
 1. They are not **live**, i.e., they failed to sign `MISSED_BLOCK_THRESHOLD` blocks in last `BLOCK_SIGNING_WINDOW`
    blocks successfully.

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -101,9 +101,9 @@ account can be un-jailed after `UNBONDING_PERIOD`, it should not be allowed to u
 :::
 
 :::tip Important:
-A validator should not be slashed more than once within `UNBONDING_PERIOD` after they were jailed. If a validator commits multiple faults
-before `account.jailed_until`, it should only be slashed with the highest slash amount in that period (can be calculated
-using below algorithm).
+A validator should not be slashed more than once within `UNBONDING_PERIOD` after they were jailed. If a validator
+commits multiple faults before `account.jailed_until`, it should only be slashed with the highest slash amount in that
+period (can be calculated using below algorithm).
 :::
 
 #### Slashing Rate

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -55,8 +55,13 @@ not older than `MAX_EVIDENCE_AGE` in tendermint.
 ### Inactivity Punishment
 
 When a validator fails to successfully sign `MISSED_BLOCK_THRESHOLD` blocks in last `BLOCK_SIGNING_WINDOW` blocks, it is
-immediately punished by deducting funds from their bonded and unbonded amount. The funds to be deducted are calculated
+immediately punished by deducting funds from their bonded and unbonded amount and removing them from active validator
+set if the resulting bonded amount is still greater than minimum required stake. The funds to be deducted are calculated
 based on `LIVENESS_SLASH_PERCENT`.
+
+:::tip Note:
+The validator is not **jailed** in this scenario. They can immediately send a `NodeJoinTx` to join back as a validator.
+:::
 
 ### Jailing
 

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -81,11 +81,11 @@ When a validator is jailed because of a byzantine fault, their validator public 
 banned validators and cannot re-join the network as a validator with same public key.
 :::
 
-#### Un-jailing and Re-joining 
+#### Un-jailing
 
 When a jailed validator wishes to resume normal operations (after `account.jailed_until` has passed), they can create
-`UnjailTx` which marks them as un-jailed. After successful un-jailing, validators can submit a `NodeJoinTx`, which will
-add them back to validator set.
+`UnjailTx` which marks them as un-jailed. After successful un-jailing, validators can submit a `UnbondTx` and
+`WithdrawTx` to withdraw their funds.
 
 ### Slashing
 

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -65,8 +65,8 @@ before `account.jailed_until` which is set to `block_time + UNBONDING_PERIOD` wh
 network parameter which can be configured during genesis.
 
 :::tip Important:
-`block_time` used in calculating `account.jailed_until` should be the time of the block at which the validator made the
-fault, which can be obtained from `evidence` provided by tendermint (current block for liveness faults).
+`block_time` used in calculating `account.jailed_until` should be the time of the block at which the fault is detected
+(i.e., `current_block_height`).
 :::
 
 #### Un-jailing and Re-joining 
@@ -101,8 +101,9 @@ account can be un-jailed after `UNBONDING_PERIOD`, it should not be allowed to u
 :::
 
 :::tip Important:
-A validator should not be slashed more than once within `UNBONDING_PERIOD`. If we get multiple slash requests for a
-validator within `UNBONDING_PERIOD`, we should ignore all requests other than the first one.
+A validator should not be slashed more than once within `UNBONDING_PERIOD`. I a validator commits multiple faults before
+`account.jailed_until`, it should only be slashed with the highest slash amount in that period (can be calculated using
+below algorithm).
 :::
 
 #### Slashing Rate
@@ -150,4 +151,10 @@ a 20% slash.
 slashing_rate = max(liveness_slash_percent, byzantine_slash_percent) * (sqrt(validator_voting_percent_1) + sqrt(validator_voting_percent_2))^2
               = max(1, 1) * (sqrt(0.05) + sqrt(0.05))^2                // assuming liveness_slash_percent and byzantine_slash_percent are both 100%
               = 0.2
+```
+
+Finally, `slashing_amount` can be calculated by multiplying `slashing_rate` by total `bondend + unbonded` amount.
+
+```
+slash_amount = slashing_rate * (bonded_amount + unbonded_amount)
 ```

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -69,6 +69,11 @@ network parameter which can be configured during genesis.
 (i.e., `current_block_height`).
 :::
 
+:::tip Important:
+When a validator is jailed because of a byzantine fault, their validator public key is added to a list of permanently
+banned validators and cannot re-join the network as a validator with same public key.
+:::
+
 #### Un-jailing and Re-joining 
 
 When a jailed validator wishes to resume normal operations (after `account.jailed_until` has passed and the account is

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -53,7 +53,7 @@ not older than `MAX_EVIDENCE_AGE` in tendermint.
 
 ### Jailing
 
-A validator is jailed if:
+A validator is jailed if any one of the following applies:
 
 1. They are not **live**, i.e., they failed to sign `MISSED_BLOCK_THRESHOLD` blocks in last
    `BLOCK_SIGNING_WINDOW` blocks successfully. 


### PR DESCRIPTION
**Solution**: Simplify network parameters and fill gaps in current punishments specifications. Related to #80, #83 and #84. 

**How it addresses crypto-com/chain#1096?**

The problem with current implementation is that it does not take `evidence`'s `block_height` in account when calculating `slash_ratio` (it assumes `block_height = current_block_height` and takes latest `validator_voting_power` in `slash_ratio` calculations. Voting power at `current_block_height` may be different because a validator can `unbond`/`deposit` funds into their account).

This PR gets rid of proportional slashing and immediately slashes an account when they make a byzantine fault.

**How it prevents bugs like crypto-com/chain#1079?**

This PR gets rid of proportional slashing and immediately slashes an account when they make a byzantine fault.

**Note**: I've created a new file `punishments.md` but haven't linked that in `staking.md`. Fixes in `staking.md` will be done in future PRs.