### PR TITLE
LivenessTracker should be updated in EndBlock

### DIFF
--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -233,10 +233,6 @@ impl LivenessTracker {
     - Add validator address to a list of permanently banned validators.
     - Generate slashing and jailing events for validator.
 
-#### `DeliverTx`
-
-- If a new node joins the validator set using `NodeJoinTx`, add the validator address of that node to `LivenessTracker`.
-
 :::tip Note:
 An additional validation for `NodeJoinTx` will be to verify if the validator address is not present in the list of
 permanently banned validators.
@@ -244,6 +240,7 @@ permanently banned validators.
 
 #### `EndBlock`
 
-- Remove all the validators from `LivenessTracker` whose voting power was changed to zero in the block.
+- Update `LivenessTracker`, i.e., add all the validators who joined in current block and remove all the validator who,
+  left/got jailed in current block.
 - Set `response.validator_updates` for all the validators whose voting power was changed. Tendermint will remove all the
   validators whose voting power is set to zero, so, all the jailed validators should have zero voting power.

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -228,10 +228,20 @@ impl LivenessTracker {
     - Jail and slash the validator (set `jailed_until = current_block_time + UNBONDIND_PERIOD` and slash by
       `BYZANTINE_SLASH_PERCENT`). Note that, both, slashing and jailing should happen as one command, i.e., validator
       account's `nonce` will only increase by one.
-    - Remove the validator from current validator set, i.e., set their voting power to zero. Validator will get removed
-      from `LivenessTracker` in `EndBlock`.
+    - Remove the validator from current validator set, i.e., set their voting power to zero (in
+      `power_changed_in_block`). Validator will get removed from `LivenessTracker` in `EndBlock`.
     - Add validator address to a list of permanently banned validators.
     - Generate slashing and jailing events for validator.
+
+:::tip How are validator updates handled in code?
+Tendermint expects all the validator updates to be done in `EndBlock`, i.e., all the validator updates are posted to
+tendermint in `EndBlock`'s response. So, we need a mechanism to store all the validator updates happened in a block and
+post those to tendermint in `EndBlock`'s response. For this purpose, we have `power_changed_in_block` (implementation
+and variable name may vary but the idea is the same) where we store all the changes in voting power that happened in a
+block. `power_changed_in_block` is cleared at the start of each new block.
+
+So, setting voting power in `power_changed_in_block` to zero means that those validators will be removed.
+:::
 
 #### `DeliverTx`
 

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -228,20 +228,10 @@ impl LivenessTracker {
     - Jail and slash the validator (set `jailed_until = current_block_time + UNBONDIND_PERIOD` and slash by
       `BYZANTINE_SLASH_PERCENT`). Note that, both, slashing and jailing should happen as one command, i.e., validator
       account's `nonce` will only increase by one.
-    - Remove the validator from current validator set, i.e., set their voting power to zero (in
-      `power_changed_in_block`). Validator will get removed from `LivenessTracker` in `EndBlock`.
+    - Remove the validator from current validator set, i.e., set their voting power to zero. Validator will get removed
+      from `LivenessTracker` in `EndBlock`.
     - Add validator address to a list of permanently banned validators.
     - Generate slashing and jailing events for validator.
-
-:::tip How are validator updates handled in code?
-Tendermint expects all the validator updates to be done in `EndBlock`, i.e., all the validator updates are posted to
-tendermint in `EndBlock`'s response. So, we need a mechanism to store all the validator updates happened in a block and
-post those to tendermint in `EndBlock`'s response. For this purpose, we have `power_changed_in_block` (implementation
-and variable name may vary but the idea is the same) where we store all the changes in voting power that happened in a
-block. `power_changed_in_block` is cleared at the start of each new block.
-
-So, setting voting power in `power_changed_in_block` to zero means that those validators will be removed.
-:::
 
 #### `DeliverTx`
 
@@ -254,7 +244,6 @@ permanently banned validators.
 
 #### `EndBlock`
 
-- Remove all the validators from `LivenessTracker` whose voting power was changed to zero in the block (data can be
-  obtained from `power_changed_in_block`).
+- Remove all the validators from `LivenessTracker` whose voting power was changed to zero in the block.
 - Set `response.validator_updates` for all the validators whose voting power was changed. Tendermint will remove all the
   validators whose voting power is set to zero, so, all the jailed validators should have zero voting power.

--- a/docs/getting-started/punishments.md
+++ b/docs/getting-started/punishments.md
@@ -167,6 +167,7 @@ impl LivenessTracker {
     pub fn add_validator(&mut self, tendermint_validator_address: TendermintValidatorAddress) -> Result<()> {
         todo!()
     }
+
     /// Removes validator from liveness tracking
     ///
     /// # Note
@@ -175,9 +176,10 @@ impl LivenessTracker {
     pub fn remove_validator(
         &mut self, 
         tendermint_validator_address: &TendermintValidatorAddress,
-    ) -> Result<Validator> {
+    ) -> Result<()> {
         todo!()
     }
+
     /// Updates liveness of a validator with new block data
     ///
     /// # Note
@@ -186,17 +188,18 @@ impl LivenessTracker {
     pub fn update_liveness(
         &mut self, 
         tendermint_validator_address: &TendermintValidatorAddress,
-        lock_height: BlockHeight,
+        block_height: BlockHeight,
         signed: bool,
     ) -> Result<()> {
         todo!()
     }
+
     /// Checks if a validator is live or not
     ///
     /// # Note
     ///
     /// - Returns `Err` when validator with given address does not exist
-    pub fn is_live(&self, tendermint_validator_address, &TendermintValidatorAddress) -> Result<bool> {
+    pub fn is_live(&self, tendermint_validator_address: &TendermintValidatorAddress) -> Result<bool> {
         todo!()
     }
 }
@@ -225,10 +228,14 @@ impl LivenessTracker {
     - Jail and slash the validator (set `jailed_until = current_block_time + UNBONDIND_PERIOD` and slash by
       `BYZANTINE_SLASH_PERCENT`). Note that, both, slashing and jailing should happen as one command, i.e., validator
       account's `nonce` will only increase by one.
-    - Remove validator from `LivenessTracker`.
-    - Remove the validator from current validator set, i.e., set their voting power to zero.
+    - Remove the validator from current validator set, i.e., set their voting power to zero. Validator will get removed
+      from `LivenessTracker` in `EndBlock`.
     - Add validator address to a list of permanently banned validators.
     - Generate slashing and jailing events for validator.
+
+#### `DeliverTx`
+
+- If a new node joins the validator set using `NodeJoinTx`, add the validator address of that node to `LivenessTracker`.
 
 :::tip Note:
 An additional validation for `NodeJoinTx` will be to verify if the validator address is not present in the list of
@@ -237,5 +244,7 @@ permanently banned validators.
 
 #### `EndBlock`
 
+- Remove all the validators from `LivenessTracker` whose voting power was changed to zero in the block (data can be
+  obtained from `power_changed_in_block`).
 - Set `response.validator_updates` for all the validators whose voting power was changed. Tendermint will remove all the
   validators whose voting power is set to zero, so, all the jailed validators should have zero voting power.


### PR DESCRIPTION
Changes:

- `LivenessTracker` should be updated in `EndBlock`. Reason: If we do not update `LivenessTracker` in `EndBlock`, we'll have to put update statements in all the places where a validator's voting power changes to zero (jailing, unbonding, etc.). On the other hand, if we update `LivenessTracker` in `EndBlock` based on `power_changed_in_block`, we won't have to worry about updating liveness tracker in different places.
- Added instruction to add a new validator to `LivenessTracker` when they join the network as a validator using `NodeJoinTx`.
- Fixed some typos.