### PR TITLE
Problem: (Fix#119) Broken links to implementation plan in "Enclave Architecture"

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -27,7 +27,7 @@ Before diving into details, we would like to introduce you the big picture of Cr
 
 ![](./assets/big_pic.png)
 
-At the end of this getting-start document, you will be running five components:
+At the end of this getting-start document, you will be running four components:
 - `chain-abci` as main chain process.
 - `client-rpc` as rpc server for client's interactions.
 - `tendermint` for consensus.

--- a/docs/getting-started/enclave-architecture.md
+++ b/docs/getting-started/enclave-architecture.md
@@ -24,7 +24,7 @@ There are _three_ enclaves planned in Crypto.com Chain's transaction data confid
    - fetching current UTXO set transaction data; and
    - handling periodic key generation operations.
 
-For a detailed description of how these enclaves work together, please refer to the [implementation plan](../../plan.md) of transaction data confidentiality.
+For a detailed description of how these enclaves work together, please refer to the [implementation plan](https://github.com/crypto-com/chain-docs/blob/master/plan.md) of transaction data confidentiality.
 
 ## Transaction validation
 
@@ -44,17 +44,17 @@ In production deployment, both of these processes should be on the same machine 
 - Chain ABCI is executed on the developer laptop (any operating system), and the transaction validation enclave runs inside a Docker container (using the software-simulation mode).
 - Chain ABCI is executed on the developer laptop (any operating system), and the transaction validation enclave runs on a remote Linux machine (using the hardware mode).
 
-For further details, please refer to the [transaction flow chat](../../plan.md#transaction-validation-enclave-tve) between Tendermint, ABCI and transaction validation enclave.
+For further details, please refer to the [transaction flow chat](https://github.com/crypto-com/chain-docs/blob/master/plan.md#transaction-validation-enclave-tve) between Tendermint, ABCI and transaction validation enclave.
 
 ### Data sealing
 
-As previous transaction data is needed for transaction validation, it needs to be persisted locally. The enclave uses the process of “data sealing” for this purposes. To make the data accessible for future upgrades and other enclaves, it should be sealed with MRSIGNER-derived keys. For further details, please refer to [TEE primitives](../../plan.md#tee-primitives).
+As previous transaction data is needed for transaction validation, it needs to be persisted locally. The enclave uses the process of “data sealing” for this purposes. To make the data accessible for future upgrades and other enclaves, it should be sealed with MRSIGNER-derived keys. For further details, please refer to [TEE primitives](https://github.com/crypto-com/chain-docs/blob/master/plan.md#tee-primitives).
 
 ## Transaction data bootstrapping
 
 As old payment data becomes inaccessible due to the periodic key rotation (see [transaction privacy](./transaction-privacy)), newly joined nodes (or nodes that went offline for some time) would need a way to bootstrap the old transaction data by connecting to enclaves of remote nodes and requesting transaction data that the other nodes have locally sealed.
 
-For further details, please refer to this [implementation plan](../../plan.md#transaction-data-bootstrapping-enclave-tdbe) of **transaction data bootstrapping enclave**.
+For further details, please refer to this [implementation plan](https://github.com/crypto-com/chain-docs/blob/master/plan.md#transaction-data-bootstrapping-enclave-tdbe) of **transaction data bootstrapping enclave**.
 
 ### Lite client inside enclaves
 
@@ -76,7 +76,7 @@ For this purpose, there needs to be an enclave that can unseal the previously st
 
 This process would again require establishing a secure connection channel between the client and the enclave (if it is remote) as in the transaction data bootstrapping – the difference is that it may only be one-side attested, as the client may not have access to the enclave architecture.
 
-For further details, please refer to this [documentation](../../plan.md#transaction-query-enclave-tqe-optional--for-client-infrastructure) on **transaction query enclave**.
+For further details, please refer to this [documentation](https://github.com/crypto-com/chain-docs/blob/master/plan.md#reliance-on-the-intel-infrastructure) on **transaction query enclave**.
 
 ## Transaction creation
 

--- a/docs/getting-started/network-parameters.md
+++ b/docs/getting-started/network-parameters.md
@@ -4,10 +4,11 @@ This section aims to collect and provide brief description of all the mentioned 
 
 #### Staking-related parameters
 
-| Key              | Description                     |
-| ---------------- | ------------------------------- |
-| `UNBOUND_PERIOD` | The time duration of unbonding  |
-| `MAX_VALIDATORS` | The maximum number of validator |
+| Key                           | Description                     |
+| ----------------------------- | ------------------------------- |
+| `unbonding_period`              | The time duration of unbonding  |
+| `max_validators`              | The maximum number of validator |
+| `required_council_node_stake` |                                 |
 
 #### Reward parameters
 
@@ -24,11 +25,11 @@ This section aims to collect and provide brief description of all the mentioned 
 | Key                       | Description                                                                |
 | ------------------------- | -------------------------------------------------------------------------- |
 | `MAX_EVIDENCE_AGE`        | Maximum age of evidence                                                    |
-| `BLOCK_SIGNING_WINDOW`    | Window to calculate validators's liveness                                  |
-| `JAIL_DURATION`           | The time period for jailing                                                |
-| `MISSED_BLOCK_THRESHOLD`  | Threshold of total missed blocks                                           |
-| `BYZANTINE_SLASH_PERCENT` | Maximum percentage of stake reduction for byzantine validators             |
-| `LIVENESS_SLASH_PERCENT`  | Maximum percentage of stake reduction for validators with low availability |
+| `block_signing_window`    | Window to calculate validators's liveness                                  |
+| `jail_duration`           | The time period for jailing                                                |
+| `missed_block_threshold`  | Threshold of total missed blocks                                           |
+| `byzantine_slash_percent` | Maximum percentage of stake reduction for byzantine validators             |
+| `liveness_slash_percent`  | Maximum percentage of stake reduction for validators with low availability |
 
 #### Transaction fee parameters
 

--- a/docs/getting-started/network-parameters.md
+++ b/docs/getting-started/network-parameters.md
@@ -4,11 +4,11 @@ This section aims to collect and provide brief description of all the mentioned 
 
 #### Staking-related parameters
 
-| Key                           | Description                     |
-| ----------------------------- | ------------------------------- |
-| `unbonding_period`              | The time duration of unbonding  |
-| `max_validators`              | The maximum number of validator |
-| `required_council_node_stake` |                                 |
+| Key                           | Description                                           |
+| ----------------------------- | ----------------------------------------------------- |
+| `unbonding_period`            | The time duration of unbonding                        |
+| `max_validators`              | The maximum number of validator                       |
+| `required_council_node_stake` | The minimum staking amount required to be a validator |
 
 #### Reward parameters
 

--- a/docs/getting-started/notes-on-production-deployment.md
+++ b/docs/getting-started/notes-on-production-deployment.md
@@ -1,15 +1,15 @@
 # Notes on Production Deployment
 
-- See [Tendermint notes on running in production](https://docs.tendermint.com/master/tendermint-core/running-in-production.html)
+- See [Tendermint notes on running in production](https://docs.tendermint.com/master/tendermint-core/running-in-production.html) and [notes on setting up a validator](https://docs.tendermint.com/master/tendermint-core/validators.html#setting-up-a-validator)
 - Validators shouldn’t be exposed directly to the internet
 - RPC shouldn’t be exposed directly to the internet (as it currently doesn’t support rate-limiting, authentication…)
-- Validator block signing should be via [kms](https://github.com/tendermint/kms#tendermint-kms-)
+- Validator block signing should be via [tmkms](https://github.com/iqlusioninc/tmkms)
 
 ## Setting up Tendermint KMS for signing blocks (only for validators / council nodes)
-Currently (tmkms v0.6), the system is still a bit Cosmos-centric, so the setup is slightly quirky.
+Currently (tmkms v0.7), the system is still a bit Cosmos-centric, so the setup is slightly quirky.
 
 ### Configuration
-As per the [example](https://github.com/tendermint/kms/blob/master/tmkms.toml.example), create `~/.tmkms/tmkms.toml` (or any path) with something like:
+As per the [example](https://github.com/iqlusioninc/tmkms/blob/develop/tmkms.toml.example), create `~/.tmkms/tmkms.toml` (or any path) with something like:
 
 ```
 [[chain]]

--- a/docs/getting-started/transaction.md
+++ b/docs/getting-started/transaction.md
@@ -68,7 +68,7 @@ All these types should also contain metadata, such as [network ID](./chain-id-an
 | `WithdrawUnbondedTx` | Nonce, account         | UTXOs                                                                        | Yes            | Yes         |
 | `UnbondStakeTx`      | Nonce, amount, account | Moves funds from `bonded` to `unbonded` under the same account with timelock | Yes            | No          |
 
-Please also refer to this [flowchart](./send_your_first_transaction.md#types-of-transaction-and-address) that shows different types of transaction and how they interact with each other.
+Please also refer to this [flowchart](./send_your_first_transaction.md#send-your-first-transaction) that shows different types of transaction and how they interact with each other.
 
 ### Advanced Types:
 

--- a/docs/modules/staking-state.md
+++ b/docs/modules/staking-state.md
@@ -180,7 +180,7 @@ Jailed validators won't be slashed again for byzantine faults detected in jailin
 
 ### Nonce
 
-The nonce is the number of transactions sent from the staking address, which is:
+The nonce is the of transactions that have the witness of the staking address, which includes:
 
 - `WithdrawTx`
 - `UnbondTx`


### PR DESCRIPTION
Solution: 
- Point them to `plan.md` on github.

Extra:
- `network-parameters.md`, `transaction.md` and ` getting-started/README.md ` Small fixes;
- `notes-on-production-deployment.md` Updated to the latest tmkms page ;
- `staking-state.md` Make it more precise after the discussion with @yihuang.