### PR TITLE
Problem: Pending status is not explanined

### DIFF
--- a/docs/getting-started/transaction-accounting-model.md
+++ b/docs/getting-started/transaction-accounting-model.md
@@ -65,7 +65,7 @@ For example, by using [clinent-cli](../wallets/client-cli.md#staking-operations)
 
 - For slashing related information:
   - `Jailed Until` is the time until which current account is jailed;
-  - `Punishment Type` represents the type of [punishment](./staking.md#punishments) that will be imposed on the account (if any);
+  - `Punishment Type` represents the type of [punishment](./reward-and-punishments.md#validator-punishments) that will be imposed on the account (if any);
   - `Slash Amount` is the amount of penalty.
 
 ### Staked State Storage

--- a/docs/wallets/client-cli.md
+++ b/docs/wallets/client-cli.md
@@ -58,12 +58,12 @@ Similarly, we can also change the Tendermint URL when running ClientCLI, update 
 
 A list of supported environment variables of ClientCLI is listed below:
 
-| Option                   | Description                                     | Type       | Default Value           |
-| ------------------------ | ----------------------------------------------- | ---------- | ----------------------- |
-| CRYPTO_CLIENT_DEBUG      | How detail should the debug message be on error | true/false | false                   |
-| CRYPTO_CHAIN_ID          | Full Chain ID                                   | String     | ---                     |
-| CRYPTO_CLIENT_STORAGE    | Wallet storage directory                        | Storage    | .storage                |
-| CRYPTO_CLIENT_TENDERMINT | Tendermint URL                                  | String     | http://localhost:26657/ |
+| Option                   | Description                                     | Type              | Default Value                  |
+| ------------------------ | ----------------------------------------------- | ----------------- | ------------------------------ |
+| CRYPTO_CLIENT_DEBUG      | How detail should the debug message be on error | true/false        | false                          |
+| CRYPTO_CHAIN_ID          | Full Chain ID                                   | String            | ---                            |
+| CRYPTO_CLIENT_STORAGE    | Wallet storage directory                        | Storage directory | .storage                       |
+| CRYPTO_CLIENT_TENDERMINT | Websocket endpoint for tendermint               | String            | ws://localhost:26657/websocket |
 
 ## Wallet operations
 
@@ -350,7 +350,7 @@ Staking operations involve the interaction between _transfer_ address and _staki
 
   ::: tip
 
-  - The unbonded amount will go to the `Unbonded` balance in your staking address. It will be locked until the `unbonding_period` has passed. Details about the deposited funds in the staking address can be found by checking its [staking state](#state-check-the-staking-state)
+  - The unbonded amount will go to the `Unbonded` balance in your staking address. It will be locked until the `unbonding_period` has passed. Details about the deposited funds in the staking address can be found by checking its [staking state](#state-check-the-staking-state).
 
   :::
 
@@ -394,8 +394,10 @@ Enter authentication token: ## Insert your authentication token ##
 :::
 
 :::tip Note
-Please note that `balance` will only show your _transferable_ balance, for _staking_ related balance, please use the `state` command. It is suggested that you should `sync` your wallet before checking the balance to obtain the current balance.
-:::
+
+- Please note that `balance` will only show your _transferable_ balance, for _staking_ related balance, please check it with the `state` [command](#state-check-the-staking-state).
+- Once a transaction has been sent, the transaction amount and fees will go to "_Pending_" status. The balance will be settled once the transaction has been confirmed. Therefore, It is suggested that you should `sync` your wallet before checking the balance to obtain the latest balance.
+  :::
 
 ### `history` - Check your transaction history
 
@@ -459,18 +461,19 @@ See [here](../getting-started/staking.md#joining-the-network) for the actual req
 
 ### Unjailing a validator
 
-Validator could be punished and [jailed](../getting-started/staking.md#jailing) due to network misbehaviour. After the jailing period has passed, one can broadcast a `UnjailTx` to unjail the validator and resume its normal operations by
+Validator could be [punished](../getting-started/reward-and-punishments.md#validator-punishments) and [jailed](../getting-started/reward-and-punishments.md#jailing) due to network misbehaviour. After the jailing period has passed, one can broadcast a `UnjailTx` to unjail the validator and resume its normal operations by
 
 ```bash
 $ ./bin/client-cli transaction new --name Default --type unjail
 ```
 
-## Export & Import Tx
+### Export & Import Tx
 
 As mentioned before, sender should add the receiver's view-key to the transaction. Because sender can't push data directly to the receiver. However, it is also possible to send / receive a payment by directly exchanging the (raw) transaction payload data. The sender (who creates the transaction) would export it, the receiver would import it and check the transaction data locally and check the transaction ID against the distributed ledger. Following explains the flow:
 
 1.  **Sender**: Get your transaction id from the history, you may need to sync before running the following command:
     ::: details Example: Obtain the transaction id
+
     ```bash
     \$ ./bin/client-cli history --limit ? --offset ? --name <sender_wallet>
     Enter authentication token: ## Insert your authentication token ##
@@ -486,18 +489,20 @@ As mentioned before, sender should add the receiver's view-key to the transactio
 
 1.  **Sender**: Export the target transaction payload from the sender's wallet:
     ::: details Example: Export the raw transaction data
+
     ```bash
     \$ ./bin/client-cli transaction export --id <transaction_id> --name <sender_wallet>
     Enter authentication token: ## Insert your authentication token ##
 
         ## transaction_payload_example ##
         eyJ0eCI6eyJ0eXBlIjoiVHJhbnNmZXJUcmFuc2FjdGlvbiIsImlucHV0cyI6W3siaWQiOiI3ZDk3NzVjNTcyODQ1ZjRlNzRjOGU5Y2Q1NjhkZjk4Mjk0NjQ1ODM1NDA5OGQzZDBlZjcxNzRmYmQ3NDdkMDhkIiwiaW5kZXgiOjF9XSwib3V0cHV0cyI6W3siYWRkcmVzcyI6InRjcm8xenR2MDZ6dzRtdHZ3NnhhZ25jMGdheTJkbXN5OHo5cjN4N2RwdGoycW5tdnBoNDY1YXQ5c251M2x1YSIsInZhbHVlIjoiMTAwMDAwMDAwMDAwIiwidmFsaWRfZnJvbSI6bnVsbH0seyJhZGRyZXNzIjoidGNybzFtODd5cTYwMmM2M2ZrY3p2ejZwcW5xY3JzOXZ0bnEzOHRuZjQ1a3lqMG1rdHY1ZGVkaDBxYTNmcHB2IiwidmFsdWUiOiI1OTk5ODk5OTk5OTk3ODg3IiwidmFsaWRfZnJvbSI6bnVsbH1dLCJhdHRyaWJ1dGVzIjp7ImNoYWluX2hleF9pZCI6IjQyIiwiYWxsb3dlZF92aWV3IjpbeyJ2aWV3X2tleSI6IjAzZDRkNWZiN2Q4MjJiZGUwZjYwOTgwNmU3ZTEzMDVmNTI3NjYzZmM5YWU2ZmZhMjJiNDVhMDc1NDRhOGU5OGY1YiIsImFjY2VzcyI6IkFsbERhdGEifV19fSwiYmxvY2tfaGVpZ2h0IjozMjQ2Mn0
-      ```
+    ```
 
     :::
 
 1.  **Receiver**: The transaction can be imported into receiver's wallet by
     ::: details Example: Import the raw transaction data
+
     ```bash
     \$ ./bin/client-cli transaction import --tx <transaction_payload> --name <receiver_wallet>
 

--- a/docs/wallets/client-cli.md
+++ b/docs/wallets/client-cli.md
@@ -396,7 +396,7 @@ Enter authentication token: ## Insert your authentication token ##
 :::tip Note
 
 - Please note that `balance` will only show your _transferable_ balance, for _staking_ related balance, please check it with the `state` [command](#state-check-the-staking-state).
-- Once a transaction has been sent, the transaction amount and fees will go to "_Pending_" status. The balance will be settled once the transaction has been confirmed. Therefore, It is suggested that you should `sync` your wallet before checking the balance to obtain the latest balance.
+- Once a transaction has been sent, the remaining amount ( _Total_ amount subtracted by the transaction amount and fees) will go to "_Pending_" status. The balance will be settled once the transaction has been confirmed. Therefore, It is suggested that you should `sync` your wallet before checking the balance to obtain the latest balance.
   :::
 
 ### `history` - Check your transaction history


### PR DESCRIPTION
- Added description to `Pending` status in [wallet balance](https://github.com/crypto-com/chain-docs/compare/master...lezzokafka:pending_amount_quickfix?expand=1#diff-7986c9141c951876d6a918408aaadc8cR399);
- Updated the default setting for [websocket endpoint for tendermint](https://github.com/crypto-com/chain-docs/compare/master...lezzokafka:pending_amount_quickfix?expand=1#diff-7986c9141c951876d6a918408aaadc8cR66);
- Redirected some links in the docs.      