### PR TITLE
Not Found errores on "Getting Started"

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -5,8 +5,8 @@ Thanks for you interest in Crypto.com Chain. This is the technical documentation
 ### What's next?
 
 #### Try Running a Node
-- [Join Thaler Testnet](./thaler-testnet): Try running Full Nodes or Council Nodes (Validators) connected to our Thaler Testnet.
-- [Build Latest Development Version](./local-devnet): Try running latest development network (Devnet)
+- [Join Thaler Testnet](./thaler-testnet.md): Try running Full Nodes or Council Nodes (Validators) connected to our Thaler Testnet.
+- [Build Latest Development Version](./local-devnet.md): Try running latest development network (Devnet)
 
 #### Learn about protocol design
 - Read our [Protocol Design](/protocol/)


### PR DESCRIPTION
This will fix the 404 errores of 
- **"Join Thaler Testnet"** and 
- **"Build Latest Development Version"** 

on the current [home page](https://chain.crypto.com/docs/getting-started/) of getting started.

Thanks @foreseaz  for pointing it out. 