### PR TITLE
"Not Found" errores in docs 

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -9,7 +9,7 @@ Thanks for you interest in Crypto.com Chain. This is the technical documentation
 - [Build Latest Development Version](./local-devnet.md): Try running latest development network (Devnet)
 
 #### Learn about protocol design
-- Read our [Protocol Design](/protocol/)
+- Read our [Protocol Design](/protocol/enclave-architecture.md#enclave-architecture)
 
 #### Wallet Management
 - [Overview](/wallets/)

--- a/docs/getting-started/local-devnet.md
+++ b/docs/getting-started/local-devnet.md
@@ -4,7 +4,7 @@
 this page is for building and running the latest development version of the chain for testing purpose only. development branch is under active development and is highly unstable and subject to breaking changes. you should expect a moderate amount of troubleshooting work is required.
 
 for anyone interested in joining the crypto.com chain testnet,
-please refer to our [testnet documentation](./thaler-testnet).
+please refer to our [testnet documentation](./thaler-testnet.md).
 :::
 
 By following this tutorial, you can compile and run the latest development version of Crypto.com Chain from scratch. It is intended for testing purpose only.
@@ -274,4 +274,4 @@ If you need to stop the processes and initialize a new chain
 
 ### Congratulations
 
-Congratulations, now the environment to run Crypto.com Chain is all set. Let's on on and start [sending your first transaction](./send-your-first-transaction).
+Congratulations, now the environment to run Crypto.com Chain is all set. Let's on on and start [sending your first transaction](./send-your-first-transaction.md).

--- a/docs/getting-started/send-your-first-transaction.md
+++ b/docs/getting-started/send-your-first-transaction.md
@@ -1,10 +1,10 @@
 # Devnet: Send Your First Transaction
 
 ::: warning Caution
-This page is a continuation of [Devnet: Running Latest Development Node](./local-devnet) for development.
+This page is a continuation of [Devnet: Running Latest Development Node](./local-devnet.md) for development.
 
 For anyone interested more on wallet management, getting testing token from the faucet and sending transactions,
-please refer to [ClientCLI](../wallets/client-cli).
+please refer to [ClientCLI](../wallets/client-cli.md).
 :::
 
 Crypto.com Chain uses a hybrid transaction accounting model with different transaction types. Before sending the transaction, please notice that the genesis fund is stored in a _staking_ address at the beginning. You first have to **withdraw** it to UTXO:

--- a/docs/protocol/client-flow.md
+++ b/docs/protocol/client-flow.md
@@ -8,23 +8,23 @@ Currently, the used filter is the Bloom filter used in Ethereum defined with the
 
 The full node inserts the following data into the filter at the moment:
 
-1. “view keys” (secp256k1 public keys allowed to view the content) in the case of transactions producing UTXOs (see [transaction types](./transaction) and [transaction privacy mechanism](./transaction-privacy) for more details).
-2. Staked state addresses in the case of transactions manipulating accounts (see [accounting details](./transaction-accounting-model)).
+1. “view keys” (secp256k1 public keys allowed to view the content) in the case of transactions producing UTXOs (see [transaction types](./transaction.md) and [transaction privacy mechanism](./transaction-privacy.md) for more details).
+2. Staked state addresses in the case of transactions manipulating accounts (see [accounting details](./transaction-accounting-model.md)).
 
 ## Client knows the transaction data
 
-Each block header includes an application hash (“APP_HASH”, see [consensus](./consensus) for details). As a part of it is a root of a Merkle tree of valid transactions, a client can check whether its known transaction was included in a block:
+Each block header includes an application hash (“APP_HASH”, see [consensus](./consensus.md) for details). As a part of it is a root of a Merkle tree of valid transactions, a client can check whether its known transaction was included in a block:
 
 1. Get the block’s application hash / header information.
-2. Compute the transaction ID from transaction data (see [transaction](./transaction)).
+2. Compute the transaction ID from transaction data (see [transaction](./transaction.md)).
 3. Check a Merkle inclusion proof where the transaction ID is one of the leaves, and a part of the application hash is the root.
 
 ## Client doesn’t know the transaction data
 
-If the client doesn’t know transaction data, it can collect valid transaction identifiers from blocks that matched its data using the block-level filter. If the transaction data was transparent (staked state operations), the client can decode transaction directly by requesting the full block data. If the transaction data was obfuscated (payments), the client needs to contact an enclave and prove they can access transaction data using view key signatures (see [transaction privacy](./transaction-privacy) and [enclave architecture](./enclave-architecture) for more details).
+If the client doesn’t know transaction data, it can collect valid transaction identifiers from blocks that matched its data using the block-level filter. If the transaction data was transparent (staked state operations), the client can decode transaction directly by requesting the full block data. If the transaction data was obfuscated (payments), the client needs to contact an enclave and prove they can access transaction data using view key signatures (see [transaction privacy](./transaction-privacy.md) and [enclave architecture](./enclave-architecture.md) for more details).
 
 Clients are responsible for their own confidential data treatment – the use of view keys (whether reused or not), requesting transaction data (e.g. from multiple enclaves when not the client isn’t running their own full node) etc.
 
 ## Payment transaction submission
 
-When the client wishes to submit a payment transaction (UTXO-based), they will construct a plain signed transaction and submit it to one of the full node’s enclaves over a secure channel (see [enclave architecture](./enclave-architecture)).
+When the client wishes to submit a payment transaction (UTXO-based), they will construct a plain signed transaction and submit it to one of the full node’s enclaves over a secure channel (see [enclave architecture](./enclave-architecture.md)).

--- a/docs/protocol/consensus.md
+++ b/docs/protocol/consensus.md
@@ -34,7 +34,7 @@ The main RPC methods are used `broadcast_tx_(a)sync` and `abci_query`.
 | -------------------- |
 
 
-This method takes “tx” parameter which is application-specific binary data (see [transaction serialization](./serialization) for details on Chain binary format). The transaction binary payload is either hex-encoded (when called with the URI method) or base64-encoded (when called with JSON-RPC).
+This method takes “tx” parameter which is application-specific binary data (see [transaction serialization](./serialization.md) for details on Chain binary format). The transaction binary payload is either hex-encoded (when called with the URI method) or base64-encoded (when called with JSON-RPC).
 
 | abci_query |
 | ---------- |
@@ -49,13 +49,13 @@ The **“application hash”** is a compact representation of the overall ABCI a
 In Crypto.com Chain, the application hash is a [Blake3](https://github.com/BLAKE3-team/BLAKE3) hash of several components:
 
 - Root of a Merkle tree of a valid transaction in a given block;
-- Root of a sparse Merkle trie of staked states (see [accounting details](./transaction-accounting-model));
-- Binary serialized state of rewards pool (see [serialization](./serialization) for details on Chain binary format and [genesis](./genesis) for details on “state”);
+- Root of a sparse Merkle trie of staked states (see [accounting details](./transaction-accounting-model.md));
+- Binary serialized state of rewards pool (see [serialization](./serialization.md) for details on Chain binary format and [genesis](./genesis.md) for details on “state”);
 - Serialised [network parameters](./network-parameters.md).
 
 ## Conventions
 
-As [genesis](./genesis) information is taken from the Ethereum network, the same address format is used (i.e. hexadecimal encoding of 20-bytes from a keccak-256 hash of a secp256k1 public key).
+As [genesis](./genesis.md) information is taken from the Ethereum network, the same address format is used (i.e. hexadecimal encoding of 20-bytes from a keccak-256 hash of a secp256k1 public key).
 
 For Tendermint data, its conventions must be followed:
 
@@ -65,5 +65,5 @@ For Tendermint data, its conventions must be followed:
 For Crypto.com Chain, it has the following conventions:
 
 - _Chain-ID_: this is a string in Tendermint’s genesis.json. In Crypto.com Chain, it should end with two hex digits;
-- [Network-ID](./chain-id-and-network-id): a single byte determined by the two last hex digits of Chain-ID. It is included in metadata of every transaction to specify the network;
-- Transactions, addresses etc.: Please refer to transaction [binary serialization](./serialization), [accounting model](./transaction-accounting-model), [addresses / witness](./signature-schemes) and [format / types](./transaction).
+- [Network-ID](./chain-id-and-network-id.md): a single byte determined by the two last hex digits of Chain-ID. It is included in metadata of every transaction to specify the network;
+- Transactions, addresses etc.: Please refer to transaction [binary serialization](./serialization.md), [accounting model](./transaction-accounting-model.md), [addresses / witness](./signature-schemes.md) and [format / types](./transaction.md).

--- a/docs/protocol/enclave-architecture.md
+++ b/docs/protocol/enclave-architecture.md
@@ -1,6 +1,6 @@
 # Enclave Architecture
 
-The primary initial use of Trusted Execution Environments (TEE) is for enforcing payment data confidentiality (see [transaction privacy](./transaction-privacy)), while maintaining flexibility and auditability. Other use cases may be developed in the long term.
+The primary initial use of Trusted Execution Environments (TEE) is for enforcing payment data confidentiality (see [transaction privacy](./transaction-privacy.md)), while maintaining flexibility and auditability. Other use cases may be developed in the long term.
 
 ## Technology
 
@@ -28,7 +28,7 @@ For a detailed description of how these enclaves work together, please refer to 
 
 ## Transaction validation
 
-The validation of transactions that involve payment obfuscated transaction outputs (see [transaction types](./transaction) and [accounting model](./transaction-accounting-model)) need to happen inside enclaves. Detailed transaction processing can found [here](https://github.com/crypto-com/chain-docs/blob/master/docs/modules/transactions.md)
+The validation of transactions that involve payment obfuscated transaction outputs (see [transaction types](./transaction.md) and [accounting model](./transaction-accounting-model.md)) need to happen inside enclaves. Detailed transaction processing can found [here](https://github.com/crypto-com/chain-docs/blob/master/docs/modules/transactions.md)
 
 For the ease of development, the transaction validation happens in a separate process. The Chain ABCI application process then communicates with this process using a simple request-reply protocol over a 0MQ socket:
 
@@ -52,13 +52,13 @@ As previous transaction data is needed for transaction validation, it needs to b
 
 ## Transaction data bootstrapping
 
-As old payment data becomes inaccessible due to the periodic key rotation (see [transaction privacy](./transaction-privacy)), newly joined nodes (or nodes that went offline for some time) would need a way to bootstrap the old transaction data by connecting to enclaves of remote nodes and requesting transaction data that the other nodes have locally sealed.
+As old payment data becomes inaccessible due to the periodic key rotation (see [transaction privacy](./transaction-privacy.md)), newly joined nodes (or nodes that went offline for some time) would need a way to bootstrap the old transaction data by connecting to enclaves of remote nodes and requesting transaction data that the other nodes have locally sealed.
 
 For further details, please refer to this [implementation plan](https://github.com/crypto-com/chain-docs/blob/master/plan.md#transaction-data-bootstrapping-enclave-tdbe) of **transaction data bootstrapping enclave**.
 
 ### Lite client inside enclaves
 
-Each enclave should internally run a lite client that would keep track of the validator set, so that it can safely store the latest “app hash” (see [consensus](./consensus#application_hash)).
+Each enclave should internally run a lite client that would keep track of the validator set, so that it can safely store the latest “app hash” (see [consensus](./consensus.md#application_hash)).
 
 ### Mutual attestation
 
@@ -70,7 +70,7 @@ Beyond the mutual attestation, enclaves should perform additional checks against
 
 ## Transaction querying
 
-As mentioned in [client flows](./client-flow), clients may not know their transaction data and would need to submit blind queries requesting data of some payment transactions.
+As mentioned in [client flows](./client-flow.md), clients may not know their transaction data and would need to submit blind queries requesting data of some payment transactions.
 
 For this purpose, there needs to be an enclave that can unseal the previously stored transaction data, verify the client query and return the matching transactions.
 
@@ -86,6 +86,6 @@ For this purpose, there needs to be an enclave that can access the current rando
 
 ## Enclave breaches
 
-If enclaves were breached, it would lead to reduced confidentiality – there would still be a level of confidentiality, as the multi-signature scheme in Chain records only limited information in the blockchain (see [signature schemes](./signature-schemes)). It would only affect transactions that were obfuscated with the breached key, as the key would be periodically rotated (see [transaction privacy](./transaction-privacy)).
+If enclaves were breached, it would lead to reduced confidentiality – there would still be a level of confidentiality, as the multi-signature scheme in Chain records only limited information in the blockchain (see [signature schemes](./signature-schemes.md)). It would only affect transactions that were obfuscated with the breached key, as the key would be periodically rotated (see [transaction privacy](./transaction-privacy.md)).
 
-Note that the breach wouldn’t lead to the loss of ledger integrity, as that is preserved by the [consensus algorithm](./consensus).
+Note that the breach wouldn’t lead to the loss of ledger integrity, as that is preserved by the [consensus algorithm](./consensus.md).

--- a/docs/protocol/genesis.md
+++ b/docs/protocol/genesis.md
@@ -126,13 +126,13 @@ The balances of these dedicated addresses are put to the initial “Rewards Pool
 DEX, multisig etc. contracts should be avoided during the Step 3
 :::
 
-- If the address is an externally owned account and corresponds to the initial staking address of one of council nodes, its balance starts as “bonded” in the corresponding staked state (see [accounting mode](./transaction-accounting-model) for more details).
-- Otherwise (i.e. the address is an externally owned account, but not of any validators), the address balance starts as “unbonded” in the corresponding staked state (see [accounting mode](./transaction-accounting-model) for more details).
+- If the address is an externally owned account and corresponds to the initial staking address of one of council nodes, its balance starts as “bonded” in the corresponding staked state (see [accounting mode](./transaction-accounting-model.md) for more details).
+- Otherwise (i.e. the address is an externally owned account, but not of any validators), the address balance starts as “unbonded” in the corresponding staked state (see [accounting mode](./transaction-accounting-model.md) for more details).
 
 From this initial genesis state, the initial “application hash” (APP HASH) is computed and set in the corresponding genesis.json file of Tendermint and compiled statically into the enclave binaries (that need to be signed by the developer production keys).
 
 ## Tendermint extra information
 
-As described in [consensus](./consensus), Tendermint executes with the application-specific code via ABCI.
+As described in [consensus](./consensus.md), Tendermint executes with the application-specific code via ABCI.
 
 The genesis information (network parameters, initial validators etc.) is set in the `app_data` field in genesis.json – this information is then passed to the ABCI application in the InitChainRequest.

--- a/docs/protocol/transaction-accounting-model.md
+++ b/docs/protocol/transaction-accounting-model.md
@@ -23,7 +23,7 @@ For this reason, we chose the mixed model where:
 - UTXO is used for payments / value transfers
 - Account-model is used for network operations (“staked state”)
 
-Different types of transactions and how they relate to these accounting are [described in transactions](./transaction).
+Different types of transactions and how they relate to these accounting are [described in transactions](./transaction.md).
 
 ### Staked state
 
@@ -61,7 +61,7 @@ For example, by using [client-cli](../wallets/client-cli.md#staking-operations),
 
   As it may take time for the network evidence of malicious activity (e.g. double signing) to appear, the stake cannot be withdrawn immediately and is first moved to the “unbonded” balance.
 
-- The `Unbonded` balance can be withdrawn (into transaction outputs) after `Unbonded From` time if the account was not jailed / slashed (see [staking](./staking)).
+- The `Unbonded` balance can be withdrawn (into transaction outputs) after `Unbonded From` time if the account was not jailed / slashed (see [punishment](./reward-and-punishments.md#validator-punishments)).
 
 - For slashing related information:
   - `Jailed Until` is the time until which current account is jailed;

--- a/docs/protocol/transaction-privacy.md
+++ b/docs/protocol/transaction-privacy.md
@@ -20,15 +20,15 @@ Payment data need confidentiality for many reasons, including compliance with di
 
 ## Payloads
 
-Depending on the transaction type (see [transaction types](./transaction) and its [processing](https://github.com/crypto-com/chain-docs/blob/master/docs/modules/transactions.md#transaction-processing)), some of its parts (transaction data, witness or both) need to be obfuscated. In that case, the broadcasted transaction binary payload includes:
+Depending on the transaction type (see [transaction types](./transaction.md) and its [processing](https://github.com/crypto-com/chain-docs/blob/master/docs/modules/transactions.md#transaction-processing)), some of its parts (transaction data, witness or both) need to be obfuscated. In that case, the broadcasted transaction binary payload includes:
 
 - Transaction ID (if the transaction data is obfuscated)
 - List of transaction inputs (if relevant) and the number of outputs (if relevant)
 - Symmetric encryption-related metadata (key generation, nonce / initialization vector)
 - Obfuscated payload
 
-The encryption inside enclaves (see [enclave architecture](./enclave-architecture)) is done using “authenticated encryption with associated data” (AEAD) scheme – the initial planned algorithm is [AEAD_AES_128_GCM_SIV](https://tools.ietf.org/html/rfc8452).
+The encryption inside enclaves (see [enclave architecture](./enclave-architecture.md)) is done using “authenticated encryption with associated data” (AEAD) scheme – the initial planned algorithm is [AEAD_AES_128_GCM_SIV](https://tools.ietf.org/html/rfc8452).
 
 ## Periodic key generation
 
-The active set of validators is involved in periodic generation of new keys that are then used by all full node enclaves on the network – the key distribution is done over mutually attested secure channels (see [enclave architecture](./enclave-architecture)).
+The active set of validators is involved in periodic generation of new keys that are then used by all full node enclaves on the network – the key distribution is done over mutually attested secure channels (see [enclave architecture](./enclave-architecture.md)).

--- a/docs/protocol/transaction.md
+++ b/docs/protocol/transaction.md
@@ -8,22 +8,22 @@ Each transaction has an identifier (typically shortened as TX ID). It is defined
 | -------------------------------------------------- |
 
 
-See [serialization](./serialization) for more details about the transaction binary format.
+See [serialization](./serialization.md) for more details about the transaction binary format.
 
 ## Witness
 
-See [signature-schemes](./signature-schemes) for more details
+See [signature-schemes](./signature-schemes.md) for more details
 
 ## Textual Address Representation
 
-Crypto.com Chain supports threshold / multi-signature addresses that are represented as a single hash (see [signature-schemes](./signature-schemes)) which is different from Ethereum.
+Crypto.com Chain supports threshold / multi-signature addresses that are represented as a single hash (see [signature-schemes](./signature-schemes.md)) which is different from Ethereum.
 
 To represent the underlying byte array in a textual form, [Bech32](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) is used. The convention for the human-readable prefix is the following:
 
 - `cro`: mainnet payment
 - `tcro`: testnet payment
 - `dcro`: local devnet/regtest payment
-- staking addresses (see [accounting](./transaction-accounting-model)) are textually represented in hexadecimal encoding to match the initial Ethereum ones
+- staking addresses (see [accounting](./transaction-accounting-model.md)) are textually represented in hexadecimal encoding to match the initial Ethereum ones
 
 ## Transaction Fees
 
@@ -53,7 +53,7 @@ To verify a [basic transaction](#transaction-types) one would need to check:
 sum(inputs amounts) or account.unbonded/bonded == sum(outputs amounts) + fee
 ```
 
-The transaction fee goes to the [rewards pool](./reward-and-punishments#validator-rewards) to reward the validations.
+The transaction fee goes to the [rewards pool](./reward-and-punishments.md#validator-rewards) to reward the validations.
 
 ## Transaction Types
 

--- a/docs/wallets/sample-chain-wallet.md
+++ b/docs/wallets/sample-chain-wallet.md
@@ -15,7 +15,7 @@ Please follow the [instructions](https://github.com/crypto-com/sample-chain-wall
 
 ## Start ClientRPC
 
-Sample wallet is powered by [ClientRPC](./client-rpc). To run the Sample Wallet, you will have to start the ClientRPC by following the [instructions](./client-rpc#build).
+Sample wallet is powered by [ClientRPC](./client-rpc.md). To run the Sample Wallet, you will have to start the ClientRPC by following the [instructions](./client-rpc.md#build).
 
 ## Wallet Management
 


### PR DESCRIPTION
Similar to #185, this fixes the "Not Found" errores for those links without ".md"after the recent changes.