### PR TITLE
Docs update: Redirecting all modules links

### DIFF
--- a/docs/modules/staking-state.md
+++ b/docs/modules/staking-state.md
@@ -83,8 +83,10 @@ There are several variants of it:
 
 `validator.inactive_time.is_none()`
 
-> **_NOTE:_** Active validator doesn't necessarily mean the final validator take effect in tendermint, please refer to
-> [Choose final validators](#choose-final-validators)
+::: tip Note
+Active validator doesn't necessarily mean the final validator take effect in tendermint, please refer to
+[Choose final validators](#choose-final-validators)
+:::
 
 ##### Inactive
 
@@ -94,7 +96,9 @@ There are several variants of it:
 
 `validator.jailed_until.is_some()`
 
-> **_NOTE:_** Jailed implies inactive, but not vice versa
+::: tip Note
+Jailed implies inactive, but not vice versa
+:::
 
 ## State transitions
 
@@ -151,9 +155,10 @@ The reasons for dropping of bonded coins maybe:
 - Execute `UnbondTx` at `deliver_tx` event
 - Slashed for non-live or byzantine faults at `begin_block` event
 
-> **_NOTE:_** The transition happens immediately in `deliver_tx` or `begin_block` events, won't reverse automatically
-> when bonded coins become enough again even in the same block, so the activeness is always well-defined during the
-> whole process.
+::: tip Note
+The transition happens immediately in `deliver_tx` or `begin_block` events, won't reverse automatically
+when bonded coins become enough again even in the same block, so the activeness is always well-defined during the whole process.
+:::
 
 #### Jailed for byzantine faults
 
@@ -179,19 +184,20 @@ The clean up procedure will remove the validator record if:
 - Not jailed
 - `block_time >= inactive_time + cleanup_period`
 
-> _**NOTE:**_ `cleanup_period`
->
-> Currently `cleanup_period = unbonding_period`, but logically, `cleanup_period` only needs such constraints:
->
-> - `> max_evidence_age`, so we can handle delayed byzantine evidences (inactive validator can still be slashed for
->   later detected byzantine faults)
-> - `> 2 blocks`, so we don't panic when seeing signing vote of inactivated validators
+::: tip Note for `cleanup_period`
+
+ Currently `cleanup_period = unbonding_period`, but logically, `cleanup_period` only needs such constraints:
+
+ - `> max_evidence_age`, so we can handle delayed byzantine evidences (inactive validator can still be slashed for
+   later detected byzantine faults)
+ - `> 2 blocks`, so we don't panic when seeing signing vote of inactivated validators
+   :::
 
 ### From "community node" to "clean staking"
 
 #### Bonded coins become lower than required
 
-Whenever `bonded < min_required_community_staking`, this transition happens. 
+Whenever `bonded < min_required_community_staking`, this transition happens.
 
 The other details are similar to the transition from "active validator" to "inactive validator".
 

--- a/docs/protocol/enclave-architecture.md
+++ b/docs/protocol/enclave-architecture.md
@@ -28,7 +28,7 @@ For a detailed description of how these enclaves work together, please refer to 
 
 ## Transaction validation
 
-The validation of transactions that involve payment obfuscated transaction outputs (see [transaction types](./transaction.md) and [accounting model](./transaction-accounting-model.md)) need to happen inside enclaves. Detailed transaction processing can found [here](https://github.com/crypto-com/chain-docs/blob/master/docs/modules/transactions.md)
+The validation of transactions that involve payment obfuscated transaction outputs (see [transaction types](./transaction.md) and [accounting model](./transaction-accounting-model.md)) need to happen inside enclaves. Detailed transaction processing can found [here](../modules/transactions.md)
 
 For the ease of development, the transaction validation happens in a separate process. The Chain ABCI application process then communicates with this process using a simple request-reply protocol over a 0MQ socket:
 

--- a/docs/protocol/reward-and-punishments.md
+++ b/docs/protocol/reward-and-punishments.md
@@ -168,7 +168,7 @@ The remainder of division will become rewards of the next period.
 
 ### Rewards: Documentation and its interactions with ABCI
 
-The detailed documentation of the reward mechanism can be found in [here](https://github.com/crypto-com/chain-docs/blob/master/docs/modules/reward.md).
+The detailed documentation of the reward mechanism can be found in [here](../modules/reward.md).
 
 ## Validator Punishments
 
@@ -274,7 +274,7 @@ not jailed when we receive evidence of misbehavior from tendermint.
 
 ### Punishments: Documentation and its interactions with ABCI
 
-The detailed documentation of the slashing mechanism can be found in [here](https://github.com/crypto-com/chain-docs/blob/master/docs/modules/punishment.md)
+The detailed documentation of the slashing mechanism can be found in [here](../modules/punishment.md)
 
 ### Appendix
 

--- a/docs/protocol/transaction-privacy.md
+++ b/docs/protocol/transaction-privacy.md
@@ -20,7 +20,7 @@ Payment data need confidentiality for many reasons, including compliance with di
 
 ## Payloads
 
-Depending on the transaction type (see [transaction types](./transaction.md) and its [processing](https://github.com/crypto-com/chain-docs/blob/master/docs/modules/transactions.md#transaction-processing)), some of its parts (transaction data, witness or both) need to be obfuscated. In that case, the broadcasted transaction binary payload includes:
+Depending on the transaction type (see [transaction types](./transaction.md) and its [processing](../modules/transactions.md#transaction-processing), some of its parts (transaction data, witness or both) need to be obfuscated. In that case, the broadcasted transaction binary payload includes:
 
 - Transaction ID (if the transaction data is obfuscated)
 - List of transaction inputs (if relevant) and the number of outputs (if relevant)


### PR DESCRIPTION
All links to `doc/modules` are now redirected  and will be kept under the docs site for a better viewing experience. 

Thanks for @foreseaz's suggestion 😉
