### PR TITLE
Problem: `signature_checking.sh` is not working for some validators. 

### DIFF
--- a/docs/getting-started/assets/signature_checking/check-validator-up.sh
+++ b/docs/getting-started/assets/signature_checking/check-validator-up.sh
@@ -50,7 +50,7 @@ if [[ -z "${PUBKEY}" ]]; then
 	exit 1
 fi
 set -u
-ADDRESS=$(curl --max-time 10 -sSL "${TENDERMINT_URL}/validators" | jq -r --arg PUBKEY "${PUBKEY}" '.result.validators[] | select(.pub_key.value == $PUBKEY) | .address')
+ADDRESS=$(curl --max-time 10 -sSL "${TENDERMINT_URL}/validators?per_page=300" | jq -r --arg PUBKEY "${PUBKEY}" '.result.validators[] | select(.pub_key.value == $PUBKEY) | .address')
 if [[ -z "${ADDRESS}" ]]; then
 	echo "The validator is not active ❌"
 	exit 1


### PR DESCRIPTION
**Problem:** 
Thanks @allthatjazzleo : 
> Our script for validator check didn’t take care pagination (default is 30 per_page) so it didn’t show the rest of validators.

**Solution:**
Increase the check to `300` per_page. 